### PR TITLE
Saner recursive lunit mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@
 top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 test:
-	cd $(top)/unit; lua test_cli_filter.lua
+	cd $(top)/unit; lua test_lunit.lua && lua test_cli_filter.lua
 

--- a/unit/test_cli_filter.lua
+++ b/unit/test_cli_filter.lua
@@ -1,6 +1,23 @@
+--[[
+    Unit tests for code in the Pawsey slurm lua cli_filter.
+
+    The cli_filter provides three global functions as part of
+    the slurm lua cli_filter API. It also uses a number of
+    local functions in the implementation of these API functions.
+
+    These unit tests aim to provide some test coverage of
+    both the API functions and the local implementation functions,
+    though at this point in time only tests for the latter have
+    been implemented.
+]]--
+
 lunit = require('lunit')
 
--- mock slurm interface:
+-- Mock slurm interface:
+--
+-- Slurm itself exports some interfaces to slurm functionality
+-- and key constants to the cli_filter lua program; mock these
+-- for isolated unit testing directly in the global environment.
 
 slurm_log_error_tbl = {}
 slurm_log_debug_tbl = {}
@@ -15,11 +32,11 @@ end
 slurm.SUCCESS = 0
 slurm.ERROR = -1
 
--- schlep in cli_filter; returns table of local functions to test
+-- Schlep in cli_filter; returns table of local functions to test.
 
 clif_functions = dofile("../luas/cli_filter.lua")
 
--- test suite:
+-- Test suite:
 
 T = {}
 function T.test_tokenize()
@@ -80,6 +97,7 @@ local mock_show_partition_output_tbl = {
             TRESBillingWeights=CPU=1,gres/GPU=64"
 }
 
+-- provide a substitute for invoking `scontrol partition info`
 local function mock_run_show_partition(partition)
     local out = ''
     if not partition or partition == '' then

--- a/unit/test_cli_filter.lua
+++ b/unit/test_cli_filter.lua
@@ -96,7 +96,7 @@ local function mock_run_show_partition(partition)
 end
 
 function T.test_get_default_partition()
-    local get_default_partition = lunit.mock_function(clif_functions.get_default_partition, nil, { run_show_partition = mock_run_show_partition })
+    local get_default_partition = lunit.mock_function_upvalues(clif_functions.get_default_partition, { run_show_partition = mock_run_show_partition }, true)
     local eq = lunit.test_eq_v
 
     assert(eq('work', get_default_partition()))
@@ -112,7 +112,7 @@ function T.test_get_default_partition()
 end
 
 function T.test_get_partition_info()
-    local get_partition_info = lunit.mock_function(clif_functions.get_partition_info, nil, { run_show_partition = mock_run_show_partition })
+    local get_partition_info = lunit.mock_function_upvalues(clif_functions.get_partition_info, { run_show_partition = mock_run_show_partition }, true)
     local eq = lunit.test_eq_v
 
     local pinfo_work = get_partition_info('work')

--- a/unit/test_lunit.lua
+++ b/unit/test_lunit.lua
@@ -1,0 +1,138 @@
+lunit = require('lunit')
+
+local T = {}
+local test_eq = lunit.test_eq
+local run_tests_through = lunit.run_tests_through
+local run_tests = lunit.run_tests
+
+print(run_tests)
+
+function T.test_run_tests_filters()
+    local test_set = {}
+    local function log_test(name)
+        if name == nil then return end
+        test_set[name] = true
+    end
+    local function value_set(tbl)
+        set = {}
+        for _, v in pairs(tbl) do set[v] = true end
+        return set
+    end
+
+    local nop = function () end
+    local suite = { a1 = nop, a2 = nop, b1 = nop, b2 = nop, x1 = 3, x2 = false, x3 = 'str' }
+
+    -- only function values in the suite should be considered
+    test_set = {}
+    run_tests_through(log_test, suite)
+    assert(test_eq(value_set({'a1','a2','b1','b2'}), test_set))
+
+    -- test matching filter
+    test_set = {}
+    run_tests_through(log_test, suite, '^b')
+    assert(test_eq(value_set({'b1','b2'}), test_set))
+
+    -- test excluding filter
+    test_set = {}
+    run_tests_through(log_test, suite, '2$')
+    assert(test_eq(value_set({'a2','b2'}), test_set))
+end
+
+function T.test_test_eq()
+    -- non-table equality
+
+    assert(test_eq(0, 0))
+    assert(not test_eq(1, 0))
+    assert(test_eq('', ''))
+
+    assert(test_eq('fish', 'fish'))
+    assert(not test_eq('fish', 'fowl'))
+    assert(test_eq(true, true))
+    assert(not test_eq(false, true))
+
+    local nop = function () end
+    local nop2 = lunit.clone_function(nop)
+
+    assert(test_eq(nop, nop))
+    assert(not test_eq(nop2, nop))
+
+    -- non-recursive table comparison
+
+    assert(test_eq({}, {}))
+    assert(test_eq({ a = 1, b = { c = 2, d = 3 }}, { a = 1, b = { c = 2, d = 3 }}))
+    assert(not test_eq({ b = { c = 2, d = 3 }}, { a = 1, b = { c = 2, d = 3 }}))
+    assert(not test_eq({ a = 1, b = { c = 2, d = 3 }}, { a = 1, b = { d = 3 }}))
+
+    -- rescursive table comparison
+
+    local x = { a = 1, b = { top = {}, c = 3 }}
+    x.b.top = x
+    local y = {}
+    y = { a = 1, b = { top = {}, c = 3 }}
+    y.b.top = y
+
+    assert(test_eq(x, y))
+    y.b.top = x -- still equivalent
+    assert(test_eq(x, y))
+    y.b.top = {} -- not equivalent
+    assert(not test_eq(x, y))
+
+    x = { 1, {} }
+    x[2] = x
+    y = { 1, {} }
+    y[2] = y
+    assert(test_eq(x, y))
+
+    y = { 1, {1, {} } }
+    y[2][2] = y
+    assert(test_eq(x, y))
+
+    y = { 1, {1, {1, {} } } }
+    y[2][2][2] = y
+    assert(test_eq(x, y))
+
+    y[2][2][2] = {}
+    assert(not test_eq(x, y))
+
+    -- mutually recursive table comparison
+    x = { 1, {} }
+    y = { 1, {} }
+    x[2] = y
+    y[2] = x
+    assert(test_eq(x, y))
+
+    y[2] = { 1, x }
+    assert(test_eq(x, y))
+
+    y[2] = { 1, x, 3 }
+    assert(not test_eq(x, y))
+end
+
+function T.test_clone_function()
+    local function make_fns()
+        local a = 'A'
+        local b = 'B'
+        local function concat_ab() return a..b end
+        local function set_a(x) a = x end
+        local function set_b(x) b = x end
+        return concat_ab, set_a, set_b
+    end
+
+    local concat_ab, set_a, set_b = make_fns()
+    local concat_ab_bis = lunit.clone_function(concat_ab)
+
+    -- check concat_ab_bis has same upvalues, viz. a and b.
+
+    assert(test_eq('AB', concat_ab()))
+    assert(test_eq('AB', concat_ab_bis()))
+
+    set_a('X')
+    assert(test_eq('XB', concat_ab()))
+    assert(test_eq('XB', concat_ab_bis()))
+
+    set_b('Y')
+    assert(test_eq('XY', concat_ab()))
+    assert(test_eq('XY', concat_ab_bis()))
+end
+
+if not lunit.run_tests(T) then os.exit(1) end

--- a/unit/test_lunit.lua
+++ b/unit/test_lunit.lua
@@ -1,3 +1,13 @@
+--[[
+    Unit tests for the included unit-test runner 'lunit' itself.
+
+    lunit.lua provides a very simple test suite runner (tests are
+    simple functions in a table that throw an error on failure)
+    together with some functionality for modifying a function
+    for testing through mocking global state or function upvalues.
+]]--
+
+
 lunit = require('lunit')
 
 local T = {}


### PR DESCRIPTION
* Split lunit.mock_function into (global) environment mocking and upvalue mocking functions.
* Allow recursive mocking to be optional and implement recursive mocking for upvalues.
* Add lunit unit tests including specifically tests for recursive mocking.
* Add lunit unit test run to Makefile target.