### PR TITLE
Quick fixes + debug to info

### DIFF
--- a/luas/cli_filter.lua
+++ b/luas/cli_filter.lua
@@ -72,12 +72,15 @@ local function slurm_errorf(fmt, ...)
     return slurm.ERROR
 end
 
+-- Upping log verbosity in e.g. salloc for some reason does not apply
+-- to cli_filter logging. For now, use log_info and spam debug info to user.
+
 local function slurm_debug(msg)
-    slurm.log_debug("cli_filter: %s", msg)
+    slurm.log_info("cli_filter: %s", msg)
 end
 
 local function slurm_debugf(fmt, ...)
-    slurm.log_debug("cli_filter: "..fmt, ...)
+    slurm.log_info("cli_filter: "..fmt, ...)
 end
 
 -- Execute command; return captured stdout and return code.
@@ -184,7 +187,7 @@ function slurm_cli_pre_submit(options, offset)
 
     -- have any cpu resource options been passed?
     local has_explicit_cpu_request =
-        tonumber(options['cpus-per-task']) > 1 or tonumber(options['cpus-per-gpu)']) > 0 or
+        tonumber(options['cpus-per-task']) > 1 or tonumber(options['cpus-per-gpu']) > 0 or
         not is_unset(options['cores-per-socket'])
 
     -- have any gpu resrouce options been passed?

--- a/unit/lunit.lua
+++ b/unit/lunit.lua
@@ -165,7 +165,7 @@ end
 -- Mocking utilities
 
 local function clone_function(fn)
-    local new_fn = loadstring(string.dump(fn))
+    local new_fn = load(string.dump(fn))
     local i = 1
     while debug.getupvalue(fn, i) do
         debug.upvaluejoin(new_fn, i, fn, i)

--- a/unit/test_cli_filter.lua
+++ b/unit/test_cli_filter.lua
@@ -12,6 +12,10 @@ end
 function slurm.log_debug(fmt, ...)
     table.insert(slurm_log_debug_tbl, string.format(fmt, ...))
 end
+-- For now at least, cli_filter debug output is being sent via slurm.log_info.
+function slurm.log_info(fmt, ...)
+    table.insert(slurm_log_debug_tbl, string.format(fmt, ...))
+end
 slurm.SUCCESS = 0
 slurm.ERROR = -1
 


### PR DESCRIPTION
* Fix script-breaking typos in cli_filter.lua
* Apparently some installations of lua 5.3 have `loadstring` and some do not. ?!. Use `load` instead of `loadstring` in lunit.
* cli_filter logging will only ever report 'info' level with salloc, no matter what logging level salloc sets via '-v' options. ?!. For now, noisily use slurm.log_info instead of slurm.log_debug until we find a better solution.

Outstanding issues include: `salloc ... -p gpu --ntasks=1 --gpus-per-task=2` gives configuration unavailable error.