### PR TITLE
Guard debug output with SLURM_CLI_FILTER_DEBUG envvar

### DIFF
--- a/luas/cli_filter.lua
+++ b/luas/cli_filter.lua
@@ -73,14 +73,20 @@ local function slurm_errorf(fmt, ...)
 end
 
 -- Upping log verbosity in e.g. salloc for some reason does not apply
--- to cli_filter logging. For now, use log_info and spam debug info to user.
+-- to cli_filter logging. For now, use log_info and rely upon an
+-- environment variable to enable/disable debug output.
+
+local function debug_lvl()
+    local v = os.getenv('SLURM_CLI_FILTER_DEBUG')
+    return (v and tonumber(v)) or 0
+end
 
 local function slurm_debug(msg)
-    slurm.log_info("cli_filter: %s", msg)
+    if debug_lvl() > 0 then slurm.log_info("cli_filter: %s", msg) end
 end
 
 local function slurm_debugf(fmt, ...)
-    slurm.log_info("cli_filter: "..fmt, ...)
+    if debug_lvl() > 0 then slurm.log_info("cli_filter: "..fmt, ...) end
 end
 
 -- Execute command; return captured stdout and return code.

--- a/unit/test_cli_filter.lua
+++ b/unit/test_cli_filter.lua
@@ -171,8 +171,8 @@ function T.test_slurm_debug()
     local enable_debug = true
     local function mock_debug_lvl() return enable_debug and 1 or 0 end
 
-    local slurm_debug = lunit.mock_function(clif_functions.slurm_debug, nil, { debug_lvl = mock_debug_lvl })
-    local slurm_debugf = lunit.mock_function(clif_functions.slurm_debugf, nil, { debug_lvl = mock_debug_lvl })
+    local slurm_debug = lunit.mock_function_upvalues(clif_functions.slurm_debug, { debug_lvl = mock_debug_lvl }, true)
+    local slurm_debugf = lunit.mock_function_upvalues(clif_functions.slurm_debugf, { debug_lvl = mock_debug_lvl }, true)
     local eq = lunit.test_eq_v
 
     slurm_log_debug_tbl = {}

--- a/unit/test_cli_filter.lua
+++ b/unit/test_cli_filter.lua
@@ -168,8 +168,11 @@ function T.test_slurm_error()
 end
 
 function T.test_slurm_debug()
-    local slurm_debug = clif_functions.slurm_debug
-    local slurm_debugf = clif_functions.slurm_debugf
+    local enable_debug = true
+    local function mock_debug_lvl() return enable_debug and 1 or 0 end
+
+    local slurm_debug = lunit.mock_function(clif_functions.slurm_debug, nil, { debug_lvl = mock_debug_lvl })
+    local slurm_debugf = lunit.mock_function(clif_functions.slurm_debugf, nil, { debug_lvl = mock_debug_lvl })
     local eq = lunit.test_eq_v
 
     slurm_log_debug_tbl = {}
@@ -179,6 +182,13 @@ function T.test_slurm_debug()
 
     slurm_debugf('%s=%02d', 'foo', 3)
     assert(eq('cli_filter: foo=03', slurm_log_debug_tbl[2]))
+
+    slurm_log_debug_tbl = {}
+    enable_debug = false
+
+    slurm_debug('not a %s fmt')
+    slurm_debugf('%s=%02d', 'foo', 3)
+    assert(eq(0, #slurm_log_debug_tbl))
 end
 
 if not lunit.run_tests(T) then os.exit(1) end


### PR DESCRIPTION
* Keep using `slurm.log_info` for debug input, but put in place a check against SLURM_CLI_FILTER_DEBUG having a numeric value > 0.
Fixes issue #5 