### PR TITLE
In allocation allow srun to omit gpu request

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -267,7 +267,7 @@ function slurm_cli_pre_submit(options, offset)
         end
 
         -- Ensure there is some gpu request on a gpu partition
-        if not is_node_exclusive and not has_explicit_gpu_request then
+        if not is_node_exclusive and not has_explicit_gpu_request and not is_srun_in_allocation then
             return slurm_error('non-exclusive GPU allocations require a request for one or more GPUs')
         end
 

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -328,7 +328,7 @@ function T.test_cli_srun_requires_gpu()
     -- request option because `--gres=gpu:N` is not propagated to srun and we
     -- wish to permit a simple remote interactive shell case without requiring
     -- an explicit srun. Otherwise, without an existing allocation, we demand
-    -- the srun requests gpu resoruces.
+    -- the srun requests gpu resources.
 
     mock_unset('SLURM_JOB_PARTITION')
     options = { type = 'srun', partition = 'gpu', gpus = '2' }

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -324,7 +324,7 @@ function T.test_cli_srun_requires_gpu()
     local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
     local eq = lunit.test_eq_v
 
-    -- for srun outside an allocation, we allow there not to be an explicit gpu
+    -- For srun outside an allocation, we allow there not to be an explicit gpu
     -- request option because `--gres=gpu:N` is not propagated to srun and we
     -- wish to permit a simple remote interactive shell case without requiring
     -- an explicit srun. Otherwise, without an existing allocation, we demand

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -319,4 +319,50 @@ function T.test_cli_sets_memory()
     assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
 end
 
+function T.test_cli_srun_requires_gpu()
+    local tmp = lunit.mock_function_upvalues(slurm_cli_pre_submit, { run_show_partition = mock_run_show_partition }, true)
+    local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
+    local eq = lunit.test_eq_v
+
+    -- for srun outside an allocation, we allow there not to be an explicit gpu
+    -- request option because `--gres=gpu:N` is not propagated to srun and we
+    -- wish to permit a simple remote interactive shell case without requiring
+    -- an explicit srun. Otherwise, without an existing allocation, we demand
+    -- the srun requests gpu resoruces.
+
+    mock_unset('SLURM_JOB_PARTITION')
+    options = { type = 'srun', partition = 'gpu', gpus = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', gres = 'gpu:2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', ['gpus-per-node'] = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', ['gpus-per-task'] = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    mock_setenv('SLURM_JOB_PARTITION', 'gpu')
+    options = { type = 'srun', gpus = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', gres = 'gpu:2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', ['gpus-per-node'] = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', ['gpus-per-task'] = '2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    mock_unset('SLURM_JOB_PARTITION')
+end
+
 if not lunit.run_tests(T) then os.exit(1) end


### PR DESCRIPTION
* Add check for srun not being inside an allocation when asserting that there is an explicit gpu request option provided. This is needed because unlike every other gpu request option, `--gres` is not inherited by srun from the allocation request.
Fixes #19