### PR TITLE
Add --all option to scontrol show partition

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -106,7 +106,7 @@ end
 -- Run scontrol show partition; this function will be mocked in unit testing.
 
 local function run_show_partition(partition)
-    return os_execute('scontrol show partition --oneliner '..(partition or '')..' 2>/dev/null')
+    return os_execute('scontrol show partition --all --oneliner '..(partition or '')..' 2>/dev/null')
 end
 
 local function get_default_partition()


### PR DESCRIPTION
* Add `--all` to `scontrol show partition` invocation so that the filter will successfully query hidden partitions.

Fixes #22.