### PR TITLE
add explicit gpu check to avoid acceptance always getting gpu memory settings

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -249,7 +249,7 @@ function slurm_cli_pre_submit(options, offset)
                 options['mem-per-cpu'] = mem_per_hw_thread * mem_scale
             end
         end
-    else
+    elseif is_gpu_partition(partition) then
         -- Gpu partition path
 
         local pinfo = get_partition_info(partition)


### PR DESCRIPTION
With the previous change, all acceptance partition requests would get the GPU specific settings due to the all encapsulating else logic.