### PR TITLE
Tmp allocation checks

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -125,44 +125,47 @@ end
 
 -- Parse slurm strings of the form 'key=value,key=value,...' to table.
 -- Supply e.g. ':' as second argument to parse strings of the form 'key:value,...' etc.
+-- The third agument, key_pfx, is a prefix to be stripped from every key on
+-- parsing. Why does Slurm turn --gres=gpu:2,tmp:20G on the command-line into
+-- options['gres'] == 'gres/gpu:2,gres/tmp:20G'? Why does Slurm do anything?
 
-local function parse_csv_tbl(csv, key_sep)
+local function parse_csv_tbl(csv, key_sep, key_pfx)
     key_sep = key_sep or '='
+    key_pfx = key_pfx or ''
+
+    local function strip_pfx(s)
+        if key_pfx == '' then return s end
+        if string.sub(s, 1, string.len(key_pfx)) == key_pfx then
+            return string.sub(s, string.len(key_pfx)+1)
+        else
+            return s
+        end
+    end
+
     local tbl = {}
     for _, field in ipairs(tokenize(csv, ',')) do
         local k, v = table.unpack(tokenize(field, key_sep, 2))
-        if v == nil then table.insert(tbl, k)
-        else tbl[k] = v
+        if v == nil then table.insert(tbl, strip_pfx(k))
+        else tbl[strip_pfx(k)] = v
         end
     end
     return tbl
 end
 
-function pp(t, i)
-    i = i or ''
-    if type(t) ~= 'table' then return tostring(t) end
-    local s =  '{'
-    local j = 0
-    i = i .. ' '
-    for k,v in pairs(t) do
-        if type(k) ~= 'number' and tonumber(k) then k = '"' .. k .. '"' end
-        if j>0 then s = s .. '\n' .. i end
-        j = j + 1
-        s = s .. ' ' .. k .. ': ' .. pp(v, i .. string.rep(' ', string.len(k)+3))
-    end
-    if j>0 then return s .. ' }' else return s .. '}' end
-end
+-- Analagous to above, add key_pfx to keys when reassembling a csv field.
 
-local function collect_csv_tbl(tbl, key_sep)
+local function collect_csv_tbl(tbl, key_sep, key_pfx)
     key_sep = key_sep or '='
+    key_pfx = key_pfx or ''
+
     local csv = ''
     local field_sep = ''
 
     for k, v in pairs(tbl) do
         if type(k) == 'string' then
-            csv = csv .. field_sep .. k .. key_sep .. v
+            csv = csv .. field_sep .. key_pfx .. k .. key_sep .. v
         else
-            csv = csv .. field_sep .. v
+            csv = csv .. field_sep .. key_pfx .. v
         end
         field_sep = ','
     end
@@ -268,7 +271,7 @@ function slurm_cli_pre_submit(options, offset)
 
     -- A gres option, if present, may contain multiple comma-separated key:value fields that we will need to examine.
     local gres_options = {}
-    if not is_unset(options['gres']) then gres_options = parse_csv_tbl(options['gres'], ':') end
+    if not is_unset(options['gres']) then gres_options = parse_csv_tbl(options['gres'], ':', 'gres/') end
 
     -- Are we in srun that's being invoked inside an allocation?
     local is_srun_in_allocation = options['type'] == 'srun' and os.getenv('SLURM_JOB_PARTITION') ~= nil
@@ -367,7 +370,7 @@ function slurm_cli_pre_submit(options, offset)
             gres_options.gpu = gpus_per_node
             gres_options.tmp = max_tmp_str
 
-            options['gres'] = collect_csv_tbl(gres_options, ':')
+            options['gres'] = collect_csv_tbl(gres_options, ':', 'gres/')
         end
     end
 

--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -109,6 +109,11 @@ local function run_show_partition(partition)
     return os_execute('scontrol show partition --all --oneliner '..(partition or '')..' 2>/dev/null')
 end
 
+-- Run sinfo nodes -h -o %G; this function will be mocked in unit testing.
+local function run_show_node_gres(partition)
+    return os_execute('sinfo nodes -h -o %G -p '..partition..' 2>/dev/null')
+end
+
 local function get_default_partition()
     local all_pinfo_str, rc = run_show_partition()
     if rc == 0 then
@@ -199,6 +204,30 @@ local function get_partition_info(partition)
 
     if rc == 0 then
         return parse_partition_info_str(pinfo_str)
+    end
+    return nil
+end
+
+local function parse_node_gres_str(node_gres_str)
+    if not node_gres_str then return nil end
+
+    -- Expect output to be comma-separated key:value pairs.
+    -- On the assumption that the partition is homogeoneous, only look at the first line.
+
+    line = string.gsub(node_gres_str, '\n.*', '')
+    if line == '(null)' then
+        return {}
+    else
+        return parse_csv_tbl(line, ':')
+    end
+end
+
+local function get_node_gres(partition)
+    if not partition or partition == '' then return nil end
+    local node_gres_str, rc = run_show_node_gres(partition)
+
+    if rc == 0 then
+        return parse_node_gres_str(node_gres_str)
     end
     return nil
 end
@@ -320,6 +349,25 @@ function slurm_cli_pre_submit(options, offset)
         local pinfo = get_partition_info(partition)
         if pinfo == nil then return slurm_error("unable to retrieve partition information") end
 
+        local node_gres = get_node_gres(partition)
+        if node_gres == nil then return slurm_error("unable to retrieve gpu partition node information") end
+
+        local gpus_per_node = 0
+        if node_gres.gpu then
+            gpus_per_node = string.gsub(node_gres.gpu, "%(.*", "")
+            gpus_per_node = tonumber(gpus_per_node)
+        end
+        if not gpus_per_node then return slurm_error("unable to determine GPU count from partition node information") end
+
+        local max_tmp_str = nil
+        local max_tmp_MiB = 0
+        if node_gres.tmp then
+            max_tmp_str = node_gres.tmp
+            max_tmp_MiB = convert_MiB(max_tmp_str)
+
+            if max_tmp_MiB == nil then return slurm_error("unable to determine size of tmp gres") end
+        end
+
         local tres = pinfo.TRES
         if not tres or not tres.cpu or not tres['gres/gpu'] or not tonumber(tres['gres/gpu']) then
             return slurm_error('unable to determine cpu to gpu ratio')
@@ -332,16 +380,9 @@ function slurm_cli_pre_submit(options, offset)
             return slurm_errorf('cannot explicitly request CPU resources for GPU allocation; each allocated GPU allocates %d cores', cpus_per_gpu)
         end
 
-        -- In principle, can use sinfo -o %G to get node configured gres; this information is not in pinfo.TRES.
-        -- For now, in order to address NVMe tmp allocation issues on the gpu partitions, the capacities are hard-coded:
-        --     Allocatable NVMe on tmp is 3500 GiB
-        --     Default allocation, set in job_submit.lua, is 128 GiB.
-
-        local gpus_per_node = 8
-        local max_tmp_str = '3500G'
-
-        local max_tmp_MiB = convert_MiB(max_tmp_str)
-        local non_exclusive_max_tmp_MiB = max_tmp_MiB - (gpus_per_node - 1) * convert_MiB('128G')
+        -- The default tmp allocation is hard-coded in the job_submit.lua script, and not directly accessible from the filter.
+        local default_tmp_MiB = convert_MiB('128G')
+        local non_exclusive_max_tmp_MiB = math.max(0, max_tmp_MiB - (gpus_per_node - 1) * default_tmp_MiB)
 
         -- Try to get mem-per-gpu from JobDefaults? Only used for informational purposes.
         local def_mem_per_gpu = pinfo.JobDefaults and pinfo.JobDefaults.DefMemPerGPU
@@ -361,18 +402,19 @@ function slurm_cli_pre_submit(options, offset)
         -- Reject if tmp request is too high
         local tmp_request_MiB = convert_MiB(gres_options.tmp) or 0
         if not is_node_exclusive and tmp_request_MiB > non_exclusive_max_tmp_MiB then
-            print('NOPE tmp_request_MiB', tmp_request_MiB, 'non_exclusive_max_tmp_MiB', non_exclusive_max_tmp_MiB)
-            return slurm_errorf('non-exclusive GPU allocations may request at most %d GiB of NVME tmp', non_exclusive_max_tmp_MiB/1024)
+            return slurm_errorf('non-exclusive GPU allocations may request at most %d GiB of NVMe tmp', non_exclusive_max_tmp_MiB/1024)
         end
 
         options['cpus-per-gpu'] = math.floor(cpus_per_gpu)
-        if is_node_exclusive then
+
+        if is_node_exclusive and not is_srun_in_allocation then
             gres_options.gpu = gpus_per_node
-            gres_options.tmp = max_tmp_str
+            if max_tmp_str then gres_options.tmp = max_tmp_str end
 
             options['gres'] = collect_csv_tbl(gres_options, ':', 'gres/')
         end
     end
+
 
     slurm_debugf('options on exit: %s', slurm.json_cli_options(options))
     return slurm.SUCCESS
@@ -388,6 +430,7 @@ return {
     slurm_errorf = slurm_errorf,
     slurm_debug = slurm_debug,
     slurm_debugf = slurm_debugf,
+    get_node_gres = get_node_gres,
     get_default_partition_or_env = get_default_partition_or_env,
     parse_partition_info_str = parse_partition_info_str,
     get_partition_info = get_partition_info,

--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -13,6 +13,10 @@
     SLURM_CLI_FILTER_DEBUG is set to a number greater than zero.
 ]]
 
+-- $Date$, $Revision$ substituted by keyword script in staging.
+local git_date = '$Date$'
+local git_revision = '$Revision$'
+
 --[[
     tokenize(str, pattern, max_tokens)
 
@@ -27,10 +31,6 @@
     - If the pattern matches a zero-length subsring, it will only be considered
       to describe a separator if the preceding token would be non-empty.
 ]]
-
--- $Date$, $Revision$ substituted by keyword script in staging.
-local git_date = '$Date$'
-local git_revision = '$Revision$'
 
 local function tokenize(str, pattern, max_tokens)
     if #str == 0 then return {} end
@@ -123,6 +123,52 @@ local function get_default_partition_or_env()
     return os.getenv('SLURM_JOB_PARTITION') or get_default_partition()
 end
 
+-- Parse slurm strings of the form 'key=value,key=value,...' to table.
+-- Supply e.g. ':' as second argument to parse strings of the form 'key:value,...' etc.
+
+local function parse_csv_tbl(csv, key_sep)
+    key_sep = key_sep or '='
+    local tbl = {}
+    for _, field in ipairs(tokenize(csv, ',')) do
+        local k, v = table.unpack(tokenize(field, key_sep, 2))
+        if v == nil then table.insert(tbl, k)
+        else tbl[k] = v
+        end
+    end
+    return tbl
+end
+
+function pp(t, i)
+    i = i or ''
+    if type(t) ~= 'table' then return tostring(t) end
+    local s =  '{'
+    local j = 0
+    i = i .. ' '
+    for k,v in pairs(t) do
+        if type(k) ~= 'number' and tonumber(k) then k = '"' .. k .. '"' end
+        if j>0 then s = s .. '\n' .. i end
+        j = j + 1
+        s = s .. ' ' .. k .. ': ' .. pp(v, i .. string.rep(' ', string.len(k)+3))
+    end
+    if j>0 then return s .. ' }' else return s .. '}' end
+end
+
+local function collect_csv_tbl(tbl, key_sep)
+    key_sep = key_sep or '='
+    local csv = ''
+    local field_sep = ''
+
+    for k, v in pairs(tbl) do
+        if type(k) == 'string' then
+            csv = csv .. field_sep .. k .. key_sep .. v
+        else
+            csv = csv .. field_sep .. v
+        end
+        field_sep = ','
+    end
+    return csv
+end
+
 local function parse_partition_info_str(pinfo_str)
     if not pinfo_str then return nil end
 
@@ -134,12 +180,7 @@ local function parse_partition_info_str(pinfo_str)
         if k == 'JobDefaults' or k == 'TRES' or k == 'TRESBillingWeights' then
             local rhs = {}
             if v ~= '(null)' then
-                for _, subfield in ipairs(tokenize(v, ',')) do
-                    local k, v = table.unpack(tokenize(subfield, '=', 2))
-                    if v == nil then rhs.insert(k)
-                    else rhs[k] = v
-                    end
-                end
+                rhs = parse_csv_tbl(v, '=')
             end
             pinfo[k] = rhs
         else
@@ -157,6 +198,23 @@ local function get_partition_info(partition)
         return parse_partition_info_str(pinfo_str)
     end
     return nil
+end
+
+local function convert_MiB(memory)
+    local scale_tbl = {
+        t = 1024*1024, T = 1024*1024,
+        g = 1024,      G = 1024,
+        m = 1,         M = 1,
+        k = 1/1024,    K = 1/1024
+    }
+
+    if tonumber(memory) then return tonumber(memory) end
+    if type(memory) ~= 'string' then return nil end
+
+    local scale = scale_tbl[string.sub(memory, -1)]
+    memory = tonumber(string.sub(memory, 1, string.len(memory)-1))
+
+    if not scale or not memory then return nil else return memory * scale end
 end
 
 -- Slurm CLI filter interface functions:
@@ -208,6 +266,10 @@ function slurm_cli_pre_submit(options, offset)
     -- the slurm cli_filter lua API differ between the json reporting and between the C-backed lua 'options' table.)
     local function is_unset(x)  return x == nil or x == '-2' or x == 'unset' or x == '0' end
 
+    -- A gres option, if present, may contain multiple comma-separated key:value fields that we will need to examine.
+    local gres_options = {}
+    if not is_unset(options['gres']) then gres_options = parse_csv_tbl(options['gres'], ':') end
+
     -- Are we in srun that's being invoked inside an allocation?
     local is_srun_in_allocation = options['type'] == 'srun' and os.getenv('SLURM_JOB_PARTITION') ~= nil
 
@@ -218,7 +280,7 @@ function slurm_cli_pre_submit(options, offset)
 
     -- have any gpu resrouce options been passed?
     local has_explicit_gpu_request =
-        not is_unset(options['gres']) or not is_unset(options['gpus']) or
+        not is_unset(gres_options.gpu) or not is_unset(options['gpus']) or
         not is_unset(options['gpus-per-node']) or not is_unset(options['gpus-per-task'])
 
     -- have any mem resource options been passed, excluding a request for all node memory?
@@ -256,13 +318,27 @@ function slurm_cli_pre_submit(options, offset)
         if pinfo == nil then return slurm_error("unable to retrieve partition information") end
 
         local tres = pinfo.TRES
-        if not tres or not tres.cpu or not tres['gres/gpu'] then return slurm_error('unable to determine cpu to gpu ratio') end
+        if not tres or not tres.cpu or not tres['gres/gpu'] or not tonumber(tres['gres/gpu']) then
+            return slurm_error('unable to determine cpu to gpu ratio')
+        end
+
         local cpus_per_gpu = tonumber(tres.cpu)/tonumber(tres['gres/gpu'])
         if tonumber(options['threads-per-core']) == 1 then cpus_per_gpu = cpus_per_gpu/2 end
 
         if has_explicit_cpu_request and not is_srun_in_allocation then
             return slurm_errorf('cannot explicitly request CPU resources for GPU allocation; each allocated GPU allocates %d cores', cpus_per_gpu)
         end
+
+        -- In principle, can use sinfo -o %G to get node configured gres; this information is not in pinfo.TRES.
+        -- For now, in order to address NVMe tmp allocation issues on the gpu partitions, the capacities are hard-coded:
+        --     Allocatable NVMe on tmp is 3500 GiB
+        --     Default allocation, set in job_submit.lua, is 128 GiB.
+
+        local gpus_per_node = 8
+        local max_tmp_str = '3500G'
+
+        local max_tmp_MiB = convert_MiB(max_tmp_str)
+        local non_exclusive_max_tmp_MiB = max_tmp_MiB - (gpus_per_node - 1) * convert_MiB('128G')
 
         -- Try to get mem-per-gpu from JobDefaults? Only used for informational purposes.
         local def_mem_per_gpu = pinfo.JobDefaults and pinfo.JobDefaults.DefMemPerGPU
@@ -279,9 +355,19 @@ function slurm_cli_pre_submit(options, offset)
             return slurm_error('non-exclusive GPU allocations require a request for one or more GPUs')
         end
 
+        -- Reject if tmp request is too high
+        local tmp_request_MiB = convert_MiB(gres_options.tmp) or 0
+        if not is_node_exclusive and tmp_request_MiB > non_exclusive_max_tmp_MiB then
+            print('NOPE tmp_request_MiB', tmp_request_MiB, 'non_exclusive_max_tmp_MiB', non_exclusive_max_tmp_MiB)
+            return slurm_errorf('non-exclusive GPU allocations may request at most %d GiB of NVME tmp', non_exclusive_max_tmp_MiB/1024)
+        end
+
         options['cpus-per-gpu'] = math.floor(cpus_per_gpu)
         if is_node_exclusive then
-            options['gres'] = 'gpu:8'
+            gres_options.gpu = gpus_per_node
+            gres_options.tmp = max_tmp_str
+
+            options['gres'] = collect_csv_tbl(gres_options, ':')
         end
     end
 
@@ -292,6 +378,9 @@ end
 -- return table of local functions for unit testing
 return {
     tokenize = tokenize,
+    parse_csv_tbl = parse_csv_tbl,
+    collect_csv_tbl = collect_csv_tbl,
+    convert_MiB = convert_MiB,
     slurm_error = slurm_error,
     slurm_errorf = slurm_errorf,
     slurm_debug = slurm_debug,

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -106,6 +106,71 @@ function T.test_tokenize()
     assert(eq({'a', 'b', 'c=d'}, tokenize('a=b=c=d', '=', 3)))
 end
 
+function T.test_parse_csv_tbl()
+    local parse_csv_tbl = clif_functions.parse_csv_tbl
+    local eq = lunit.test_eq_v
+
+    assert(eq({}, parse_csv_tbl('')))
+    assert(eq({'abc'}, parse_csv_tbl('abc')))
+
+    assert(eq({abc = '3'}, parse_csv_tbl('abc=3')))
+    assert(eq({abc = '4'}, parse_csv_tbl('abc=4', '=')))
+    assert(eq({abc = '5'}, parse_csv_tbl('abc:5', ':')))
+
+    assert(eq({[1] = 'foo', [2] = 'bar', ['3'] = 'three', empty = '', fish = 'cake'},
+        parse_csv_tbl('3=three,foo,bar,empty=,fish=cake')))
+end
+
+function T.test_collect_csv_tbl()
+    local parse_csv_tbl = clif_functions.parse_csv_tbl
+    local collect_csv_tbl = clif_functions.collect_csv_tbl
+    local eq = lunit.test_eq_v
+
+    -- for array-like tables, order should be preserved
+    assert(eq('', collect_csv_tbl({})))
+    assert(eq('foo,bar', collect_csv_tbl({'foo', 'bar'})))
+
+    assert(eq('foo:3', collect_csv_tbl({ foo = 3 }, ':')))
+    assert(eq('bar=x=y', collect_csv_tbl({ bar = 'x=y' }, '=')))
+
+    -- order may be arbitrary, so check round-trip with parse_csv_tbl.
+
+    local tbl_in = { foo = 4, 'quux', 'xyzzzy', bar = 'baz' }
+    local tbl_check = { foo = '4', 'quux', 'xyzzzy', bar = 'baz' }
+    assert(eq(tbl_check, parse_csv_tbl(collect_csv_tbl(tbl_in))))
+    assert(eq(tbl_check, parse_csv_tbl(collect_csv_tbl(tbl_in, ':'), ':')))
+    assert(eq(tbl_check, parse_csv_tbl(collect_csv_tbl(tbl_in, '='), '=')))
+end
+
+function T.test_convert_MiB()
+    local convert_MiB = clif_functions.convert_MiB
+    local eq = lunit.test_eq_v
+
+    assert(eq(0, convert_MiB(0)));
+    assert(eq(0, convert_MiB('0')));
+    assert(eq(123, convert_MiB(123)));
+    assert(eq(123, convert_MiB('123')));
+    assert(eq(123.5, convert_MiB(123.5)));
+    assert(eq(123.5, convert_MiB('123.5')));
+
+    assert(eq(nil, convert_MiB('123x')));
+
+    assert(eq(0.5, convert_MiB('512k')));
+    assert(eq(0.5, convert_MiB('512K')));
+
+    assert(eq(123.5, convert_MiB('123.5m')));
+    assert(eq(123.5, convert_MiB('123.5M')));
+
+    assert(eq(512, convert_MiB('0.5g')));
+    assert(eq(512, convert_MiB('0.5G')));
+
+    assert(eq(512, convert_MiB('0.5g')));
+    assert(eq(512, convert_MiB('0.5G')));
+
+    assert(eq(1179648, convert_MiB('1.125T')));
+    assert(eq(1179648, convert_MiB('1.125T')));
+end
+
 local mock_show_partition_output_tbl = {
     work = "PartitionName=work AllowGroups=ALL AllowAccounts=ALL \z
             AllowQos=ALL AllocNodes=ALL Default=YES QoS=N/A \z
@@ -337,6 +402,15 @@ function T.test_cli_srun_requires_gpu()
     options = { type = 'srun', partition = 'gpu', gres = 'gpu:2' }
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
+    options = { type = 'srun', partition = 'gpu', gres = 'tmp:100G,gpu:2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', gres = 'tmp:100G' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', gres = 'gpu:0' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
     options = { type = 'srun', partition = 'gpu', ['gpus-per-node'] = '2' }
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
@@ -363,6 +437,58 @@ function T.test_cli_srun_requires_gpu()
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
     mock_unset('SLURM_JOB_PARTITION')
+end
+
+function T.test_cli_srun_tmp_requests()
+    local tmp = lunit.mock_function_upvalues(slurm_cli_pre_submit, { run_show_partition = mock_run_show_partition }, true)
+    local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
+    local convert_MiB = clif_functions.convert_MiB
+    local parse_csv_tbl = clif_functions.parse_csv_tbl
+    local eq = lunit.test_eq_v
+
+    -- For srun outside an allocation, we allow there not to be an explicit gpu
+    -- request option because `--gres=gpu:N` is not propagated to srun and we
+    -- wish to permit a simple remote interactive shell case without requiring
+    -- an explicit srun. Otherwise, without an existing allocation, we demand
+    -- the srun requests gpu resources.
+
+    mock_unset('SLURM_JOB_PARTITION')
+
+    -- NVMe tmp allocation limits are hard-coded; see cli_filter.lua:
+    -- Max allocatable is 3500 GiB.
+    -- Max non-exclusive is 3500 - 7*128 = 2604 GiB.
+    local max_allocatable_tmp = convert_MiB('3500G')
+ 
+    options = { type = 'srun', partition = 'gpu', gres = 'tmp:2600G,gpu:2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', gres = 'tmp:2700G,gpu:2' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    -- Exclusive allocations always get the max tmp allocation.
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive', gres = 'tmp:2700G,gpu:2' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    local gres_options = parse_csv_tbl(options['gres'], ':')
+    assert(eq(max_allocatable_tmp, convert_MiB(gres_options.tmp)))
+end
+
+function T.test_cli_srun_exclusive_gres()
+    local tmp = lunit.mock_function_upvalues(slurm_cli_pre_submit, { run_show_partition = mock_run_show_partition }, true)
+    local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
+    local convert_MiB = clif_functions.convert_MiB
+    local parse_csv_tbl = clif_functions.parse_csv_tbl
+    local eq = lunit.test_eq_v
+
+    local max_allocatable_tmp = convert_MiB('3500G')
+    local gpus_per_node = 8
+
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    local gres_options = parse_csv_tbl(options['gres'], ':')
+    assert(eq(max_allocatable_tmp, convert_MiB(gres_options.tmp)))
+    assert(eq(gpus_per_node, tonumber(gres_options.gpu)))
 end
 
 if not lunit.run_tests(T) then os.exit(1) end


### PR DESCRIPTION
* Parse and re-assemble gres options for gpu count, tmp request.
* Implement hard-coded limit on non-exclusive tmp requests on gpu nodes of (effectively) 2604 GiB.
* Set gres options for exclusive allocation requests to gpu:8,tmp:3500G.
* Add unit tests for above plus extra parsing routines.

Note that between the option given on the command-line and the options table presented to the filter, Slurm adds a 'gres/' prefix to each field: `--gres=tmp:100G,gpu:2` becomes `gres/tmp:100G,gres/gpu:2` in the table. Why?