### PR TITLE
Acceptance partition mapping

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -17,29 +17,6 @@
 local git_date = '$Date$'
 local git_revision = '$Revision$'
 
--- Access constraints mapping to partition
-local constraints_mapping = {
-    askaprt = {
-        askaprt = 'askaprt'
-    },
-    copy = {
-        copy    = 'copy'
-    },
-    cpu = {
-        debug   = 'debug',
-        highmem = 'highmem',
-        work    = 'work'
-    },
-    gpu = {
-        debug   = 'gpu-dev',
-        highmem = 'gpu-highmem',
-        work    = 'gpu'
-    },
-    ['mwa-asvocopy'] = {
-        ['mwa-asvocopy'] = 'mwa-asvocopy'
-    }
-}
-
 --[[
     tokenize(str, pattern, max_tokens)
 
@@ -160,34 +137,6 @@ end
 
 local function get_default_partition_or_env()
     return os.getenv('SLURM_JOB_PARTITION') or get_default_partition()
-end
-
--- Obtain the derived partition from the provided options
--- Normally this will just be the partition value from the options or the
--- default partition. For the acceptance partition, the provided constraints
--- are used to derive which partition type they match
-
-local function get_derived_partition(options)
-    local partition = options.partition or get_default_partition_or_env()
-    if partition == 'acceptance' then
-        local constraints = options.constraint ~= nil and tokenize(options.constraint, ',') or {}
-        -- no constraints, just return the partition from options
-        if #constraints == 0 then
-            return partition
-        end
-
-        for tkey, tvalue in pairs(constraints_mapping) do
-            if existsIn(constraints, tkey) then
-                for ckey, partition in pairs(tvalue) do
-                    if existsIn(constraints, ckey) then
-                        return partition
-                    end
-                end
-            end
-        end
-    end
-
-    return partition
 end
 
 -- Parse slurm strings of the form 'key=value,key=value,...' to table.
@@ -327,6 +276,55 @@ local function collate_spank_options(opt_tbl)
     return collated
 end
 
+-- When the partition is the acceptance partition, the effective partition for
+-- the purposes of cli-filter processing is determined by the supplied
+-- constraints.
+--
+-- The acceptance_mapping table maps a constraint or a pair of constraints (as
+-- given by the first and second-level keys of the table) to a partition name.
+-- That partition name is chosen as the effective partition if that constraint
+-- or pair of constraints constitutes a subset of the supplied set of
+-- constraints given on the command line.
+
+local acceptance_mapping = {
+    askaprt = {
+        askaprt = 'askaprt'
+    },
+    copy = {
+        copy    = 'copy'
+    },
+    cpu = {
+        debug   = 'debug',
+        highmem = 'highmem',
+        work    = 'work'
+    },
+    gpu = {
+        debug   = 'gpu-dev',
+        highmem = 'gpu-highmem',
+        work    = 'gpu'
+    },
+    ['mwa-asvocopy'] = {
+        ['mwa-asvocopy'] = 'mwa-asvocopy'
+    }
+}
+
+local function effective_acceptance_partition(constraint_argument)
+    if constraint_argument == nil or acceptance_mapping == nil then return nil end
+
+    local constraints = tokenize(constraint_argument, ',')
+    for tkey, tvalue in pairs(acceptance_mapping) do
+        if existsIn(constraints, tkey) then
+            for ckey, cvalue in pairs(tvalue) do
+                if existsIn(constraints, ckey) then
+                    return cvalue
+                end
+            end
+        end
+    end
+
+    return nil
+end
+
 -- Slurm CLI filter interface functions:
 
 function slurm_cli_setup_defaults(options, early)
@@ -391,7 +389,7 @@ function slurm_cli_pre_submit(options, offset)
         not is_unset(options['cpus-per-task']) or not is_unset(options['cpus-per-gpu']) or
         not is_unset(options['cores-per-socket'])
 
-    -- have any gpu resrouce options been passed?
+    -- have any gpu resource options been passed?
     local has_explicit_gpu_request =
         not is_unset(gres_options.gpu) or not is_unset(options['gpus']) or
         not is_unset(options['gpus-per-node']) or not is_unset(options['gpus-per-task'])
@@ -405,7 +403,9 @@ function slurm_cli_pre_submit(options, offset)
     local has_gpu_power_request = spank_options['gpu-srange'] ~= nil or spank_options['gpu-power-cap'] ~= nil
 
     local is_node_exclusive = options['exclusive'] == 'exclusive' -- disregard 'user', 'mcs' possibilities.
-    local partition = get_derived_partition(options)
+
+    local partition = options['partition'] or get_default_partition_or_env()
+    if partition == 'acceptance' then partition = effective_acceptance_partition(options.constraint) or partition end
 
     if not is_gpu_partition(partition) and not is_excepted_partition(partition) then
         -- Non-gpu partition path:
@@ -531,7 +531,7 @@ return {
     slurm_debugf = slurm_debugf,
     get_node_gres = get_node_gres,
     get_default_partition_or_env = get_default_partition_or_env,
-    get_derived_partition = get_derived_partition,
+    effective_acceptance_partition = effective_acceptance_partition,
     parse_partition_info_str = parse_partition_info_str,
     get_partition_info = get_partition_info,
 }

--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -168,9 +168,9 @@ end
 -- are used to derive which partition type they match
 
 local function get_derived_partition(options)
-    local partition = options['partition'] or get_default_partition_or_env()
+    local partition = options.partition or get_default_partition_or_env()
     if partition == 'acceptance' then
-        local constraints = tokenize(options['constraint'], ',')
+        local constraints = options.constraint ~= nil and tokenize(options.constraint, ',') or {}
         -- no constraints, just return the partition from options
         if #constraints == 0 then
             return partition

--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -17,6 +17,29 @@
 local git_date = '$Date$'
 local git_revision = '$Revision$'
 
+-- Access constraints mapping to partition
+local constraints_mapping = {
+    askaprt = {
+        askaprt = 'askaprt'
+    },
+    copy = {
+        copy    = 'copy'
+    },
+    cpu = {
+        debug   = 'debug',
+        highmem = 'highmem',
+        work    = 'work'
+    },
+    gpu = {
+        debug   = 'gpu-dev',
+        highmem = 'gpu-highmem',
+        work    = 'gpu'
+    },
+    ['mwa-asvocopy'] = {
+        ['mwa-asvocopy'] = 'mwa-asvocopy'
+    }
+}
+
 --[[
     tokenize(str, pattern, max_tokens)
 
@@ -63,6 +86,17 @@ local function tokenize(str, pattern, max_tokens)
         while #tokens>0 and tokens[#tokens] == '' do tokens[#tokens] = nil end
     end
     return tokens
+end
+
+-- Test if a value exists in an array
+
+local function existsIn(array, value)
+    for i=1, #array do
+        if array[i] == value then
+            return true
+        end
+    end
+    return false
 end
 
 -- Wrappers for slurm logging
@@ -126,6 +160,34 @@ end
 
 local function get_default_partition_or_env()
     return os.getenv('SLURM_JOB_PARTITION') or get_default_partition()
+end
+
+-- Obtain the derived partition from the provided options
+-- Normally this will just be the partition value from the options or the
+-- default partition. For the acceptance partition, the provided constraints
+-- are used to derive which partition type they match
+
+local function get_derived_partition(options)
+    local partition = options['partition'] or get_default_partition_or_env()
+    if partition == 'acceptance' then
+        local constraints = tokenize(options['constraint'], ',')
+        -- no constraints, just return the partition from options
+        if #constraints == 0 then
+            return partition
+        end
+
+        for tkey, tvalue in pairs(constraints_mapping) do
+            if existsIn(constraints, tkey) then
+                for ckey, partition in pairs(tvalue) do
+                    if existsIn(constraints, ckey) then
+                        return partition
+                    end
+                end
+            end
+        end
+    end
+
+    return partition
 end
 
 -- Parse slurm strings of the form 'key=value,key=value,...' to table.
@@ -343,7 +405,7 @@ function slurm_cli_pre_submit(options, offset)
     local has_gpu_power_request = spank_options['gpu-srange'] ~= nil or spank_options['gpu-power-cap'] ~= nil
 
     local is_node_exclusive = options['exclusive'] == 'exclusive' -- disregard 'user', 'mcs' possibilities.
-    local partition = options['partition'] or get_default_partition_or_env()
+    local partition = get_derived_partition(options)
 
     if not is_gpu_partition(partition) and not is_excepted_partition(partition) then
         -- Non-gpu partition path:
@@ -458,6 +520,7 @@ end
 -- return table of local functions for unit testing
 return {
     tokenize = tokenize,
+    existsIn = existsIn,
     parse_csv_tbl = parse_csv_tbl,
     collect_csv_tbl = collect_csv_tbl,
     collate_spank_options = collate_spank_options,
@@ -468,6 +531,7 @@ return {
     slurm_debugf = slurm_debugf,
     get_node_gres = get_node_gres,
     get_default_partition_or_env = get_default_partition_or_env,
+    get_derived_partition = get_derived_partition,
     parse_partition_info_str = parse_partition_info_str,
     get_partition_info = get_partition_info,
 }

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -300,48 +300,32 @@ function T.test_get_default_partition_or_env()
     assert(eq(nil, result))
 end
 
-function T.test_get_derived_partition()
-    local get_derived_partition = clif_functions.get_derived_partition
+function T.test_effective_acceptance_partition()
+    local effective_acceptance_partition = clif_functions.effective_acceptance_partition
     local eq = lunit.test_eq_v
 
-    local mock_acceptance_with_askaprt_constraints = {partition = 'acceptance', constraint = 'askaprt'}
-    local mock_acceptance_with_copy_constraints = {partition = 'acceptance', constraint = 'copy'}
-    local mock_acceptance_with_copy_constraints = {partition = 'acceptance', constraint = 'copy'}
-    local mock_acceptance_with_debug_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,debug'}
-    local mock_acceptance_with_debug_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,debug'}
-    local mock_acceptance_with_highmem_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,highmem'}
-    local mock_acceptance_with_highmem_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,highmem'}
-    local mock_acceptance_with_mwa_asvocopy_constraints = {partition = 'acceptance', constraint = 'mwa-asvocopy'}
-    local mock_acceptance_with_work_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,work'}
-    local mock_acceptance_with_work_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,work'}
-    local mock_askaprt_partition = {partition = 'askaprt'}
-    local mock_copy_partition = {partition = 'copy'}
-    local mock_debug_partition = {partition = 'debug'}
-    local mock_gpu_dev_partition = {partition = 'gpu-dev'}
-    local mock_gpu_highmem_partition = {partition = 'gpu-highmem'}
-    local mock_gpu_partition = {partition = 'gpu'}
-    local mock_highmem_partition = {partition = 'highmem'}
-    local mock_mwa_asvocopy_partition = {partition = 'mwa-asvocopy'}
-    local mock_work_partition = {partition = 'work'}
-
-    assert(eq('askaprt', get_derived_partition(mock_acceptance_with_askaprt_constraints)))
-    assert(eq('askaprt', get_derived_partition(mock_askaprt_partition)))
-    assert(eq('copy', get_derived_partition(mock_acceptance_with_copy_constraints)))
-    assert(eq('copy', get_derived_partition(mock_copy_partition)))
-    assert(eq('debug', get_derived_partition(mock_acceptance_with_debug_cpu_constraints)))
-    assert(eq('debug', get_derived_partition(mock_debug_partition)))
-    assert(eq('gpu', get_derived_partition(mock_acceptance_with_work_gpu_constraints)))
-    assert(eq('gpu', get_derived_partition(mock_gpu_partition)))
-    assert(eq('gpu-dev', get_derived_partition(mock_acceptance_with_debug_gpu_constraints)))
-    assert(eq('gpu-dev', get_derived_partition(mock_gpu_dev_partition)))
-    assert(eq('gpu-highmem', get_derived_partition(mock_acceptance_with_highmem_gpu_constraints)))
-    assert(eq('gpu-highmem', get_derived_partition(mock_gpu_highmem_partition)))
-    assert(eq('highmem', get_derived_partition(mock_acceptance_with_highmem_cpu_constraints)))
-    assert(eq('highmem', get_derived_partition(mock_highmem_partition)))
-    assert(eq('mwa-asvocopy', get_derived_partition(mock_acceptance_with_mwa_asvocopy_constraints)))
-    assert(eq('mwa-asvocopy', get_derived_partition(mock_mwa_asvocopy_partition)))
-    assert(eq('work', get_derived_partition(mock_acceptance_with_work_cpu_constraints)))
-    assert(eq('work', get_derived_partition(mock_work_partition)))
+    local mock_acceptance_with_askaprt_constraints = 'askaprt'
+    local mock_acceptance_with_copy_constraints = 'copy'
+    local mock_acceptance_with_debug_cpu_constraints = 'cpu,debug'
+    local mock_acceptance_with_debug_gpu_constraints = 'gpu,debug'
+    local mock_acceptance_with_highmem_cpu_constraints = 'cpu,highmem'
+    local mock_acceptance_with_highmem_gpu_constraints = 'gpu,highmem'
+    local mock_acceptance_with_mwa_asvocopy_constraints = 'mwa-asvocopy'
+    local mock_acceptance_with_work_cpu_constraints = 'cpu,work'
+    local mock_acceptance_with_work_gpu_constraints = 'gpu,work'
+    local mock_acceptance_with_invalid_constraints = 'foo,bar,baz'
+    local mock_acceptance_with_missing_constraints = nil
+    assert(eq('askaprt', effective_acceptance_partition(mock_acceptance_with_askaprt_constraints)))
+    assert(eq('copy', effective_acceptance_partition(mock_acceptance_with_copy_constraints)))
+    assert(eq('debug', effective_acceptance_partition(mock_acceptance_with_debug_cpu_constraints)))
+    assert(eq('gpu', effective_acceptance_partition(mock_acceptance_with_work_gpu_constraints)))
+    assert(eq('gpu-dev', effective_acceptance_partition(mock_acceptance_with_debug_gpu_constraints)))
+    assert(eq('gpu-highmem', effective_acceptance_partition(mock_acceptance_with_highmem_gpu_constraints)))
+    assert(eq('highmem', effective_acceptance_partition(mock_acceptance_with_highmem_cpu_constraints)))
+    assert(eq('mwa-asvocopy', effective_acceptance_partition(mock_acceptance_with_mwa_asvocopy_constraints)))
+    assert(eq('work', effective_acceptance_partition(mock_acceptance_with_work_cpu_constraints)))
+    assert(eq(nil, effective_acceptance_partition(mock_acceptance_with_invalid_constraints)))
+    assert(eq(nil, effective_acceptance_partition(mock_acceptance_with_missing_constraints)))
 end
 
 function T.test_get_partition_info()

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -106,6 +106,18 @@ function T.test_tokenize()
     assert(eq({'a', 'b', 'c=d'}, tokenize('a=b=c=d', '=', 3)))
 end
 
+function T.test_existsIn()
+    local existsIn = clif_functions.existsIn
+    local eq = lunit.test_eq_v
+
+    assert(eq(false, existsIn({}, '123')))
+    assert(eq(true, existsIn({'abc'}, 'abc')))
+    assert(eq(true, existsIn({'123', 'abc', '*()'}, '123')))
+    assert(eq(true, existsIn({'123', 'abc', '*()'}, 'abc')))
+    assert(eq(true, existsIn({'123', 'abc', '*()'}, '*()')))
+    assert(eq(false, existsIn({'123', 'abc', '*()'}, '456')))
+end
+
 function T.test_parse_csv_tbl()
     local parse_csv_tbl = clif_functions.parse_csv_tbl
     local eq = lunit.test_eq_v
@@ -286,6 +298,50 @@ function T.test_get_default_partition_or_env()
     mock_show_partition_output_tbl.work = saved
 
     assert(eq(nil, result))
+end
+
+function T.test_get_derived_partition()
+    local get_derived_partition = clif_functions.get_derived_partition
+    local eq = lunit.test_eq_v
+
+    local mock_acceptance_with_askaprt_constraints = {partition = 'acceptance', constraint = 'askaprt'}
+    local mock_acceptance_with_copy_constraints = {partition = 'acceptance', constraint = 'copy'}
+    local mock_acceptance_with_copy_constraints = {partition = 'acceptance', constraint = 'copy'}
+    local mock_acceptance_with_debug_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,debug'}
+    local mock_acceptance_with_debug_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,debug'}
+    local mock_acceptance_with_highmem_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,highmem'}
+    local mock_acceptance_with_highmem_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,highmem'}
+    local mock_acceptance_with_mwa_asvocopy_constraints = {partition = 'acceptance', constraint = 'mwa-asvocopy'}
+    local mock_acceptance_with_work_cpu_constraints = {partition = 'acceptance', constraint = 'cpu,work'}
+    local mock_acceptance_with_work_gpu_constraints = {partition = 'acceptance', constraint = 'gpu,work'}
+    local mock_askaprt_partition = {partition = 'askaprt'}
+    local mock_copy_partition = {partition = 'copy'}
+    local mock_debug_partition = {partition = 'debug'}
+    local mock_gpu_dev_partition = {partition = 'gpu-dev'}
+    local mock_gpu_highmem_partition = {partition = 'gpu-highmem'}
+    local mock_gpu_partition = {partition = 'gpu'}
+    local mock_highmem_partition = {partition = 'highmem'}
+    local mock_mwa_asvocopy_partition = {partition = 'mwa-asvocopy'}
+    local mock_work_partition = {partition = 'work'}
+
+    assert(eq('askaprt', get_derived_partition(mock_acceptance_with_askaprt_constraints)))
+    assert(eq('askaprt', get_derived_partition(mock_askaprt_partition)))
+    assert(eq('copy', get_derived_partition(mock_acceptance_with_copy_constraints)))
+    assert(eq('copy', get_derived_partition(mock_copy_partition)))
+    assert(eq('debug', get_derived_partition(mock_acceptance_with_debug_cpu_constraints)))
+    assert(eq('debug', get_derived_partition(mock_debug_partition)))
+    assert(eq('gpu', get_derived_partition(mock_acceptance_with_work_gpu_constraints)))
+    assert(eq('gpu', get_derived_partition(mock_gpu_partition)))
+    assert(eq('gpu-dev', get_derived_partition(mock_acceptance_with_debug_gpu_constraints)))
+    assert(eq('gpu-dev', get_derived_partition(mock_gpu_dev_partition)))
+    assert(eq('gpu-highmem', get_derived_partition(mock_acceptance_with_highmem_gpu_constraints)))
+    assert(eq('gpu-highmem', get_derived_partition(mock_gpu_highmem_partition)))
+    assert(eq('highmem', get_derived_partition(mock_acceptance_with_highmem_cpu_constraints)))
+    assert(eq('highmem', get_derived_partition(mock_highmem_partition)))
+    assert(eq('mwa-asvocopy', get_derived_partition(mock_acceptance_with_mwa_asvocopy_constraints)))
+    assert(eq('mwa-asvocopy', get_derived_partition(mock_mwa_asvocopy_partition)))
+    assert(eq('work', get_derived_partition(mock_acceptance_with_work_cpu_constraints)))
+    assert(eq('work', get_derived_partition(mock_work_partition)))
 end
 
 function T.test_get_partition_info()


### PR DESCRIPTION
When a job is lodged onto the acceptance partition, if any constraints are used an attempt is made to update the partition name to one of the other partitions within Setonix in order for any lazy defaults to be applied to the job as if it were lodged on the other partition.

resolves #32 