### PR TITLE
No GPU power options save in exclusive GPU allocs.

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -249,6 +249,22 @@ local function convert_MiB(memory)
     if not scale or not memory then return nil else return memory * scale end
 end
 
+local function collate_spank_options(opt_tbl)
+    local collated = {}
+    if type(opt_tbl) == 'table' and type(opt_tbl.spank) == 'table' then
+        for plugin, ptbl in pairs(opt_tbl.spank) do
+            if type(ptbl) == 'table' then
+                for k, v in pairs(ptbl) do
+                    if v == nil then table.insert(collated, k)
+                    else collated[k] = v
+                    end
+                end
+            end
+        end
+    end
+    return collated
+end
+
 -- Slurm CLI filter interface functions:
 
 function slurm_cli_setup_defaults(options, early)
@@ -298,6 +314,9 @@ function slurm_cli_pre_submit(options, offset)
     -- the slurm cli_filter lua API differ between the json reporting and between the C-backed lua 'options' table.)
     local function is_unset(x)  return x == nil or x == '-2' or x == 'unset' or x == '0' end
 
+    -- Any option handled by a spank plugin is special. Gather these up in their own table.
+    local spank_options = collate_spank_options(options)
+
     -- A gres option, if present, may contain multiple comma-separated key:value fields that we will need to examine.
     local gres_options = {}
     if not is_unset(options['gres']) then gres_options = parse_csv_tbl(options['gres'], ':', 'gres/') end
@@ -321,7 +340,7 @@ function slurm_cli_pre_submit(options, offset)
         options['mem-per-cpu'] ~= nil or options['mem-per-gpu'] ~= nil or options['mem'] ~= nil and not has_all_mem_request
 
     -- have any gpu power options been supplied?
-    local has_gpu_power_request = options['spank:gpu-srange'] ~= nil or options['spank:gpu-power-cap'] ~= nil
+    local has_gpu_power_request = spank_options['gpu-srange'] ~= nil or spank_options['gpu-power-cap'] ~= nil
 
     local is_node_exclusive = options['exclusive'] == 'exclusive' -- disregard 'user', 'mcs' possibilities.
     local partition = options['partition'] or get_default_partition_or_env()
@@ -356,8 +375,9 @@ function slurm_cli_pre_submit(options, offset)
     elseif is_gpu_partition(partition) then
         -- Gpu partition path:
 
-        -- Gpu power options are not permitted in non-exclusive allocations or in srun invocations from within an allocation.
-        if has_gpu_power_request and (not is_node_exclusive or is_srun_in_allocation) then
+        -- Gpu power options are not permitted in non-exclusive allocations.
+        -- Spank options are inherited by srun invocations inside an allocation; we need to ignore them in that instance.
+        if has_gpu_power_request and not is_node_exclusive and not is_srun_in_allocation then
             return slurm_error("GPU power control options --gpu-srange and --gpu-power-cap may only be used with an exclusive GPU allocation request")
         end
 
@@ -440,6 +460,7 @@ return {
     tokenize = tokenize,
     parse_csv_tbl = parse_csv_tbl,
     collect_csv_tbl = collect_csv_tbl,
+    collate_spank_options = collate_spank_options,
     convert_MiB = convert_MiB,
     slurm_error = slurm_error,
     slurm_errorf = slurm_errorf,

--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -318,14 +318,24 @@ function slurm_cli_pre_submit(options, offset)
     -- have any mem resource options been passed, excluding a request for all node memory?
     local has_all_mem_request = options['mem'] == "0?"
     local has_explicit_mem_request =
-        options['mem-per-cpu'] ~= nil or options['mem-per-gpu'] ~= nil or options['mem'] ~=nil and not has_all_mem_request
+        options['mem-per-cpu'] ~= nil or options['mem-per-gpu'] ~= nil or options['mem'] ~= nil and not has_all_mem_request
+
+    -- have any gpu power options been supplied?
+    local has_gpu_power_request = options['spank:gpu-srange'] ~= nil or options['spank:gpu-power-cap'] ~= nil
 
     local is_node_exclusive = options['exclusive'] == 'exclusive' -- disregard 'user', 'mcs' possibilities.
     local partition = options['partition'] or get_default_partition_or_env()
 
     if not is_gpu_partition(partition) and not is_excepted_partition(partition) then
-        -- Non-gpu partition path: compute correct mem-per-cpu value from available memory and threads-per-core option
-        -- if memory has not been reqested explicitly
+        -- Non-gpu partition path:
+        -- Abort if any gpu power options have been given.
+
+        if has_gpu_power_request then
+            return slurm_error("GPU power control options --gpu-srange and --gpu-power-cap may only be used with an exclusive GPU allocation request")
+        end
+
+        -- Compute correct mem-per-cpu value from available memory and threads-per-core option if memory has not been
+        -- reqested explicitly.
 
         if not has_explicit_mem_request then
             local pinfo = get_partition_info(partition)
@@ -344,7 +354,12 @@ function slurm_cli_pre_submit(options, offset)
             end
         end
     elseif is_gpu_partition(partition) then
-        -- Gpu partition path
+        -- Gpu partition path:
+
+        -- Gpu power options are not permitted in non-exclusive allocations or in srun invocations from within an allocation.
+        if has_gpu_power_request and (not is_node_exclusive or is_srun_in_allocation) then
+            return slurm_error("GPU power control options --gpu-srange and --gpu-power-cap may only be used with an exclusive GPU allocation request")
+        end
 
         local pinfo = get_partition_info(partition)
         if pinfo == nil then return slurm_error("unable to retrieve partition information") end

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -488,35 +488,26 @@ function T.test_cli_srun_requires_gpu()
     mock_unset('SLURM_JOB_PARTITION')
 end
 
-function T.test_cli_srun_tmp_requests()
-    local tmp = lunit.mock_function_upvalues(slurm_cli_pre_submit,
+function T.test_cli_tmp_requests()
+    local slurm_cli_pre_submit = lunit.mock_function_upvalues(slurm_cli_pre_submit,
          { run_show_partition = mock_run_show_partition, run_show_node_gres = mock_run_show_node_gres }, true)
-    local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
     local convert_MiB = clif_functions.convert_MiB
     local parse_csv_tbl = clif_functions.parse_csv_tbl
     local eq = lunit.test_eq_v
-
-    -- For srun outside an allocation, we allow there not to be an explicit gpu
-    -- request option because `--gres=gpu:N` is not propagated to srun and we
-    -- wish to permit a simple remote interactive shell case without requiring
-    -- an explicit srun. Otherwise, without an existing allocation, we demand
-    -- the srun requests gpu resources.
-
-    mock_unset('SLURM_JOB_PARTITION')
 
     -- NVMe tmp allocation limits are hard-coded; see cli_filter.lua:
     -- Max allocatable is 3500 GiB.
     -- Max non-exclusive is 3500 - 7*128 = 2604 GiB.
     local max_allocatable_tmp = convert_MiB('3500G')
 
-    options = { type = 'srun', partition = 'gpu', gres = 'gres/tmp:2600G,gres/gpu:2' }
+    options = { partition = 'gpu', gres = 'gres/tmp:2600G,gres/gpu:2' }
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
-    options = { type = 'srun', partition = 'gpu', gres = 'gres/tmp:2700G,gres/gpu:2' }
+    options = { partition = 'gpu', gres = 'gres/tmp:2700G,gres/gpu:2' }
     assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
 
     -- Exclusive allocations always get the max tmp allocation.
-    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive', gres = 'gres/tmp:2700G,gres/gpu:2' }
+    options = { partition = 'gpu', exclusive = 'exclusive', gres = 'gres/tmp:2700G,gres/gpu:2' }
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
     local gres_options = parse_csv_tbl(options['gres'], ':', 'gres/')
@@ -534,12 +525,85 @@ function T.test_cli_srun_exclusive_gres()
     local max_allocatable_tmp = convert_MiB('3500G')
     local gpus_per_node = 8
 
-    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive' }
+    mock_unset('SLURM_JOB_PARTITION')
+
+    -- Just salloc/sbatch:
+    options = { partition = 'gpu', exclusive = 'exclusive' }
     assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
 
     local gres_options = parse_csv_tbl(options['gres'], ':', 'gres/')
     assert(eq(max_allocatable_tmp, convert_MiB(gres_options.tmp)))
     assert(eq(gpus_per_node, tonumber(gres_options.gpu)))
+
+   -- Srun outside allocation:
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    gres_options = parse_csv_tbl(options['gres'], ':', 'gres/')
+    assert(eq(max_allocatable_tmp, convert_MiB(gres_options.tmp)))
+    assert(eq(gpus_per_node, tonumber(gres_options.gpu)))
+
+    -- Srun inside allocation: we should not be setting gres at all if not supplied.
+    mock_setenv('SLURM_JOB_PARTITION', 'gpu')
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+    assert(eq(nil, options['gres']))
+
+    mock_unset('SLURM_JOB_PARTITION')
+end
+
+function T.test_cli_gpu_power_options_filter()
+    local tmp = lunit.mock_function_upvalues(slurm_cli_pre_submit,
+         { run_show_partition = mock_run_show_partition, run_show_node_gres = mock_run_show_node_gres }, true)
+    local slurm_cli_pre_submit = lunit.mock_function_env(tmp, { os = mock_os }, true)
+    local eq = lunit.test_eq_v
+
+    -- Options --gpu-srange and --gpu-power-cap, represented as spank:gpu-srange and spank:gpu-power-cap
+    -- in the lua options table, are only permitted on a gpu partition, with exclusive, and for salloc/sbatch
+    -- or srun run outside of an allocation.
+
+    mock_unset('SLURM_JOB_PARTITION')
+
+    -- Missing --exclusive => fail:
+    options = { partition = 'gpu', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { partition = 'gpu', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    -- With exclusive is permitted:
+    options = { partition = 'gpu', exclusive = 'exclusive', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { partition = 'gpu', exclusive = 'exclusive', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', exclusive = 'exclusive', partition = 'gpu', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', exclusive = 'exclusive', partition = 'gpu', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.SUCCESS, slurm_cli_pre_submit(options, 0)))
+
+    -- Srun within allocation cases should all fail:
+    mock_setenv('SLURM_JOB_PARTITION', 'gpu')
+    options = { type = 'srun', partition = 'gpu', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive', ['spank:gpu-srange'] = '800-900' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+
+    options = { type = 'srun', partition = 'gpu', exclusive = 'exclusive', ['spank:gpu-power-cap'] = '400' }
+    assert(eq(slurm.ERROR, slurm_cli_pre_submit(options, 0)))
+    mock_unset('SLURM_JOB_PARTITION')
 end
 
 if not lunit.run_tests(T) then os.exit(1) end


### PR DESCRIPTION
* Test for --gpu-power-cap and --gpu-srange options (represented as 'spack:gpu-power-cap' etc. in lua options table); permit these only for exclusive GPU allocations and exclusive srun invocations outside of an allocation.
* Add unit test for this functionality.
* Fix tests added previously for gres=tmp to properly distinguish between saloc/sbatch and srun contexts.

Fixes #30 