### PR TITLE
replaces comma separator with ampersand separator

### DIFF
--- a/lua-plugins/cli_filter.lua.in
+++ b/lua-plugins/cli_filter.lua.in
@@ -322,7 +322,7 @@ local acceptance_mapping = {
 local function effective_acceptance_partition(constraint_argument)
     if constraint_argument == nil or acceptance_mapping == nil then return nil end
 
-    local constraints = tokenize(constraint_argument, ',')
+    local constraints = tokenize(constraint_argument, '&')
     for tkey, tvalue in pairs(acceptance_mapping) do
         if existsIn(constraints, tkey) then
             for ckey, cvalue in pairs(tvalue) do

--- a/test/lua-unit/test_cli_filter.lua
+++ b/test/lua-unit/test_cli_filter.lua
@@ -322,15 +322,15 @@ function T.test_effective_acceptance_partition()
 
     local mock_acceptance_with_askaprt_constraints = 'askaprt'
     local mock_acceptance_with_copy_constraints = 'copy'
-    local mock_acceptance_with_debug_cpu_constraints = 'cpu,debug'
-    local mock_acceptance_with_debug_gpu_constraints = 'gpu,debug'
-    local mock_acceptance_with_highmem_cpu_constraints = 'cpu,highmem'
-    local mock_acceptance_with_highmem_gpu_constraints = 'gpu,highmem'
+    local mock_acceptance_with_debug_cpu_constraints = 'cpu&debug'
+    local mock_acceptance_with_debug_gpu_constraints = 'gpu&debug'
+    local mock_acceptance_with_highmem_cpu_constraints = 'cpu&highmem'
+    local mock_acceptance_with_highmem_gpu_constraints = 'gpu&highmem'
     local mock_acceptance_with_mwa_asvocopy_constraints = 'mwa-asvocopy'
-    local mock_acceptance_with_work_cpu_constraints = 'cpu,work'
-    local mock_acceptance_with_work_gpu_constraints = 'gpu,work'
-    local mock_acceptance_with_quantum_gh200_constraints = 'gh200,quantum'
-    local mock_acceptance_with_invalid_constraints = 'foo,bar,baz'
+    local mock_acceptance_with_work_cpu_constraints = 'cpu&work'
+    local mock_acceptance_with_work_gpu_constraints = 'gpu&work'
+    local mock_acceptance_with_quantum_gh200_constraints = 'gh200&quantum'
+    local mock_acceptance_with_invalid_constraints = 'foo&bar&baz'
     local mock_acceptance_with_missing_constraints = nil
     assert(eq('askaprt', effective_acceptance_partition(mock_acceptance_with_askaprt_constraints)))
     assert(eq('copy', effective_acceptance_partition(mock_acceptance_with_copy_constraints)))


### PR DESCRIPTION
fixes #36 

This change simply updates comma separated feature values with ampersand so the same functionality required via the acceptance partition is retained.

OR (|) separated values are not used via the acceptance partition test suite so they've not been accounted for.